### PR TITLE
Fixed multiplayer crash with out of bounds index

### DIFF
--- a/Core/Graphics/Players/PlayerPostProcessingShaderSystem.cs
+++ b/Core/Graphics/Players/PlayerPostProcessingShaderSystem.cs
@@ -72,7 +72,7 @@ public class PlayerPostProcessingShaderSystem : ModSystem
         FinalPlayerTargets.Clear();
 
         renderingToTargets = true;
-        for (int i = 0; i < Main.maxPlayers; i++)
+        for (int i = 0; i < Main.player.Length; i++)
         {
             Player player = Main.player[i];
             if (!player.active)


### PR DESCRIPTION
We should loop over the available players instead of the maximum player count when indexing into Main.player, which contains currently connected players

e.g If Main.maxPlayers = 200 but we only have 2 connected players, then we may crash at Main.player[2]

This sometimes causes a crash for all players in multiplayer when joining games, though I have not been able to reproduce this yet