### PR TITLE
Fix invalid reference to list in multiplayer

### DIFF
--- a/Content/NPCs/Bosses/Avatar/SecondPhaseForm/Behaviors/PhaseTransitions/AvatarOfEmptiness.BehaviorStates.ParadiseReclaimed.cs
+++ b/Content/NPCs/Bosses/Avatar/SecondPhaseForm/Behaviors/PhaseTransitions/AvatarOfEmptiness.BehaviorStates.ParadiseReclaimed.cs
@@ -266,11 +266,7 @@ public partial class AvatarOfEmptiness
         {
             Vector2 objectSpawnPosition = Target.Center + new Vector2(Main.rand.NextFloatDirection() * 1600f, -1950f);
             Vector2 objectVelocity = Vector2.UnitY.RotatedByRandom(0.5f) * Main.rand.NextFloat(3f, 9.5f);
-
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-            {
-                NewProjectileBetter(NPC.GetSource_FromAI(), objectSpawnPosition, objectVelocity, ModContent.ProjectileType<FallingObject>(), 0, 0f, -1, Main.rand.Next(ParadiseStaticLayerHandlers.layers.Count - 1));
-            }
+            NewProjectileBetter(NPC.GetSource_FromAI(), objectSpawnPosition, objectVelocity, ModContent.ProjectileType<FallingObject>(), 0, 0f, -1, Main.rand.Next(ParadiseStaticLayerHandlers.ParadiseStaticLayerCount - 1));
         }
 
         ScreenShakeSystem.SetUniversalRumble(6f, TwoPi, null, 0.2f);

--- a/Content/NPCs/Bosses/Avatar/SpecificEffectManagers/ParadiseReclaimed/ParadiseStaticLayerHandlers.cs
+++ b/Content/NPCs/Bosses/Avatar/SpecificEffectManagers/ParadiseReclaimed/ParadiseStaticLayerHandlers.cs
@@ -14,9 +14,14 @@ namespace NoxusBoss.Content.NPCs.Bosses.Avatar.SpecificEffectManagers.ParadiseRe
 
 public class ParadiseStaticLayerHandlers : ModSystem
 {
+    // layers appears to be unitialized on the server-side
+    // as such we have this const here instead that can notify
+    // DoBehavior_ParadiseReclaimed_StaticChase how many layers are present.
+    public const int ParadiseStaticLayerCount = 4;
+
     internal static InstancedRequestableTarget layerTarget = new InstancedRequestableTarget();
 
-    internal static List<ParadiseStaticLayer> layers = new List<ParadiseStaticLayer>(4);
+    internal static List<ParadiseStaticLayer> layers = new List<ParadiseStaticLayer>(ParadiseStaticLayerCount);
 
     public override void OnModLoad()
     {


### PR DESCRIPTION
Fixes an invalid reference to `ParadiseStaticLayerHandlers.layers` which appears to be uninitialized in multiplayer.
This is circumvented by storing the layer count in a public const instead.

The animation for when you beat avatar of emptiness is still broken, but at least the entity won't be culled with this patch and you can progress.