### PR TITLE
Update SulfuricLeafletObtainment.cs

### DIFF
--- a/Content/Items/SolynBooks/SulfuricLeafletObtainment.cs
+++ b/Content/Items/SolynBooks/SulfuricLeafletObtainment.cs
@@ -30,13 +30,16 @@ public partial class SolynBooksSystem : ModSystem
             if (Main.gamePaused)
                 return;
 
+            if(!(type == ModContent.TileType<SteamGeyser1>() || type == ModContent.TileType<SteamGeyser2>() || type == ModContent.TileType<SteamGeyser3>()))
+                return;
+
             if (!Main.rand.NextBool(SulfuricLeafletReleaseChance))
                 return;
 
             Tile t = Framing.GetTileSafely(x, y);
             Vector2 spawnPosition = new Vector2(x * 16f + 24f, y * 16f - 4f);
             bool releasesSteam = t.TileFrameX % 36 == 0 && t.TileFrameY % 36 == 0 && Collision.CanHitLine(spawnPosition, 1, 1, spawnPosition - Vector2.UnitY * 100f, 1, 1);
-            if (releasesSteam && type == ModContent.TileType<SteamGeyser1>() || type == ModContent.TileType<SteamGeyser2>() || type == ModContent.TileType<SteamGeyser3>())
+            if (releasesSteam)
             {
                 int leaflet = Item.NewItem(new EntitySource_TileUpdate(x, y), spawnPosition, SolynBookAutoloader.Books["SulfuricLeaflet"].Type);
                 if (Main.item.IndexInRange(leaflet))


### PR DESCRIPTION
Moved the tile type check to earlier in the NearbyEffectsEvent delegate function. This prevents an expensive collision check from being run for every tile near the player (instead only being run for sulfuric vents as intended), and noticeably improves performance when running the mod.

I have tested this change in game on the 1.2.24 source code with just Wrath of the Gods and its dependencies enabled. My fps when simply standing in a newly generated world increased from ~40fps to a stable 60fps, and sulfuric leaflets still spawned from sulfuric vents as normal.