### PR TITLE
Enable custom font loading regardless of operating system

### DIFF
--- a/Assets/Fonts/FontRegistry.cs
+++ b/Assets/Fonts/FontRegistry.cs
@@ -10,10 +10,6 @@ namespace NoxusBoss.Assets.Fonts;
 
 public class FontRegistry : ModSystem
 {
-    // Historically Calamity received errors when attempting to load fonts on Linux systems for their MGRR boss HP bar.
-    // Out of an abundance of caution, this mod implements the same solution as them and only uses the font on windows operating systems.
-    public static bool CanLoadFonts => Environment.OSVersion.Platform == PlatformID.Win32NT;
-
     public static FontRegistry Instance => ModContent.GetInstance<FontRegistry>();
 
     public static readonly GameCulture EnglishGameCulture = GameCulture.FromCultureName(GameCulture.CultureName.English);
@@ -27,7 +23,7 @@ public class FontRegistry : ModSystem
     {
         get
         {
-            if (Main.netMode != NetmodeID.Server && CanLoadFonts)
+            if (Main.netMode != NetmodeID.Server)
                 return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/DivineLanguageText", AssetRequestMode.ImmediateLoad).Value;
 
             return FontAssets.MouseText.Value;
@@ -42,15 +38,11 @@ public class FontRegistry : ModSystem
             if (ChineseGameCulture.IsActive)
                 return FontAssets.DeathText.Value;
 
-            if (CanLoadFonts)
-            {
-                if (RussianGameCulture.IsActive)
-                    return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/NamelessDeityTextRussian", AssetRequestMode.ImmediateLoad).Value;
+            if (RussianGameCulture.IsActive)
+                return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/NamelessDeityTextRussian", AssetRequestMode.ImmediateLoad).Value;
 
-                return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/NamelessDeityText", AssetRequestMode.ImmediateLoad).Value;
-            }
+            return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/NamelessDeityText", AssetRequestMode.ImmediateLoad).Value;
 
-            return FontAssets.MouseText.Value;
         }
     }
 
@@ -62,9 +54,8 @@ public class FontRegistry : ModSystem
             if (ChineseGameCulture.IsActive)
                 return FontAssets.DeathText.Value;
 
-            if (CanLoadFonts)
-                if (RussianGameCulture.IsActive)
-                    return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/AvatarPoemTextRussian", AssetRequestMode.ImmediateLoad).Value;
+            if (RussianGameCulture.IsActive)
+                return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/AvatarPoemTextRussian", AssetRequestMode.ImmediateLoad).Value;
 
             return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/AvatarPoemText", AssetRequestMode.ImmediateLoad).Value;
         }
@@ -78,10 +69,8 @@ public class FontRegistry : ModSystem
             if (ChineseGameCulture.IsActive || RussianGameCulture.IsActive)
                 return FontAssets.DeathText.Value;
 
-            if (CanLoadFonts)
-                return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/DraedonText", AssetRequestMode.ImmediateLoad).Value;
+            return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/DraedonText", AssetRequestMode.ImmediateLoad).Value;
 
-            return FontAssets.MouseText.Value;
         }
     }
 
@@ -93,15 +82,10 @@ public class FontRegistry : ModSystem
             if (ChineseGameCulture.IsActive)
                 return FontAssets.DeathText.Value;
 
-            if (CanLoadFonts)
-            {
-                if (RussianGameCulture.IsActive)
-                    return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/NamelessDeityTextRussian", AssetRequestMode.ImmediateLoad).Value;
+            if (RussianGameCulture.IsActive)
+                return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/NamelessDeityTextRussian", AssetRequestMode.ImmediateLoad).Value;
 
-                return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/SolynText", AssetRequestMode.ImmediateLoad).Value;
-            }
-
-            return FontAssets.MouseText.Value;
+            return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/SolynText", AssetRequestMode.ImmediateLoad).Value;
         }
     }
 
@@ -113,15 +97,10 @@ public class FontRegistry : ModSystem
             if (ChineseGameCulture.IsActive)
                 return FontAssets.DeathText.Value;
 
-            if (CanLoadFonts)
-            {
-                if (RussianGameCulture.IsActive)
-                    return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/SolynTextItalicsRussian", AssetRequestMode.ImmediateLoad).Value;
+            if (RussianGameCulture.IsActive)
+                return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/SolynTextItalicsRussian", AssetRequestMode.ImmediateLoad).Value;
 
-                return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/SolynTextItalics", AssetRequestMode.ImmediateLoad).Value;
-            }
-
-            return FontAssets.MouseText.Value;
+            return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/SolynTextItalics", AssetRequestMode.ImmediateLoad).Value;
         }
     }
 
@@ -133,10 +112,8 @@ public class FontRegistry : ModSystem
             if (ChineseGameCulture.IsActive)
                 return FontAssets.DeathText.Value;
 
-            if (CanLoadFonts)
-                return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/SolynFightDialogue", AssetRequestMode.ImmediateLoad).Value;
+            return Mod.Assets.Request<DynamicSpriteFont>("Assets/Fonts/SolynFightDialogue", AssetRequestMode.ImmediateLoad).Value;
 
-            return FontAssets.MouseText.Value;
         }
     }
 }


### PR DESCRIPTION
I made a PR recently to the main CalamityModPublic repo yesterday that does the same thing and [have been informed that they have already done this change on their private branch](https://github.com/CalamityTeam/CalamityModPublic/pull/105#issuecomment-3837537597), and should be appearing when Brainstorm comes out later this week.

Since Calamity is already doing it, and I've done extensive testing with my own forks without problems, I think that Wrath of the Gods' custom fonts can be safely enabled on non-Windows platforms as well.

This should also improve playability on these platforms too as I've noticed that some dialogue (mostly Solyn's) is completely unreadable when using the default Terraria font.

Funny Thing: Due to what I assume is a typo, the AvatarPoemText in Assets/Fonts/FontRegistry.cs will ignore the CanLoadFonts setting, so it was never a problem here anyway.

Without the patch, Solyn's dialogue is practically unreadable

<img width="3360" height="2100" alt="Screenshot From 2026-02-03 12-26-09" src="https://github.com/user-attachments/assets/77547a41-3d39-4805-9d15-41dd37b3077d" />

With the patch working on my Linux system, the dialogue is plenty readable and has no problems

<img width="3360" height="2100" alt="Screenshot From 2026-02-03 12-32-16" src="https://github.com/user-attachments/assets/a037324a-322b-4abb-8751-45b0b25ad2cb" />


